### PR TITLE
fix nil labels error

### DIFF
--- a/secapi/builders/list_options_builder.go
+++ b/secapi/builders/list_options_builder.go
@@ -10,7 +10,8 @@ const defaultLimit = 1000
 func NewListOptions() *ListOptions {
 	limit := defaultLimit
 	return &ListOptions{
-		Limit: &limit,
+		Limit:  &limit,
+		Labels: NewLabelsBuilder(),
 	}
 }
 


### PR DESCRIPTION
When labels are empty and limit not, we get an error of memory 