### PR TITLE
Creating SDK shared constants

### DIFF
--- a/internal/secatest/constants.go
+++ b/internal/secatest/constants.go
@@ -1,26 +1,8 @@
 package secatest
 
 const (
-	// Providers
-	ProviderRegionName     = "seca.region/v1"
-	ProviderRegionEndpoint = "/providers/seca.regions"
-
-	ProviderAuthorizationName     = "seca.authorization"
-	ProviderAuthorizationEndpoint = "/providers/seca.authorization"
-
-	ProviderWorkspaceName     = "seca.workspace"
-	ProviderWorkspaceEndpoint = "/providers/seca.workspace"
-
-	ProviderNetworkName     = "seca.network"
-	ProviderNetworkEndpoint = "/providers/seca.network"
-
-	ProviderComputeName     = "seca.compute"
-	ProviderComputeEndpoint = "/providers/seca.compute"
-
-	ProviderStorageName     = "seca.storage"
-	ProviderStorageEndpoint = "/providers/seca.storage"
-
-	ProviderVersion1 = "v1"
+	// Endpoints
+	providersEndpointPrefix = "/providers"
 
 	// Test Data
 

--- a/internal/secatest/constants_v1.go
+++ b/internal/secatest/constants_v1.go
@@ -1,0 +1,13 @@
+package secatest
+
+import "github.com/eu-sovereign-cloud/go-sdk/pkg/constants"
+
+const (
+	// Providers
+	ProviderRegionV1Endpoint        = providersEndpointPrefix + "/" + constants.RegionProviderV1Name
+	ProviderAuthorizationV1Endpoint = providersEndpointPrefix + "/" + constants.AuthorizationProviderV1Name
+	ProviderWorkspaceV1Endpoint     = providersEndpointPrefix + "/" + constants.WorkspaceProviderV1Name
+	ProviderNetworkV1Endpoint       = providersEndpointPrefix + "/" + constants.NetworkProviderV1Name
+	ProviderComputeV1Endpoint       = providersEndpointPrefix + "/" + constants.ComputeProviderV1Name
+	ProviderStorageV1Endpoint       = providersEndpointPrefix + "/" + constants.StorageProviderV1Name
+)

--- a/internal/secatest/tests_v1.go
+++ b/internal/secatest/tests_v1.go
@@ -10,6 +10,7 @@ import (
 	mockregion "github.com/eu-sovereign-cloud/go-sdk/mock/spec/foundation.region.v1"
 	mockstorage "github.com/eu-sovereign-cloud/go-sdk/mock/spec/foundation.storage.v1"
 	mockworkspace "github.com/eu-sovereign-cloud/go-sdk/mock/spec/foundation.workspace.v1"
+	"github.com/eu-sovereign-cloud/go-sdk/pkg/constants"
 	authorization "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.authorization.v1"
 	compute "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.compute.v1"
 	network "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.network.v1"
@@ -27,30 +28,30 @@ func ConfigureRegionV1Handler(t *testing.T, sm *http.ServeMux) *mockregion.MockS
 		Spec: schema.RegionSpec{
 			Providers: []schema.Provider{
 				{
-					Name:    ProviderWorkspaceName,
-					Url:     ProviderWorkspaceEndpoint,
-					Version: ProviderVersion1,
+					Name:    constants.WorkspaceProviderName,
+					Url:     ProviderWorkspaceV1Endpoint,
+					Version: constants.ApiVersion1,
 				},
 				{
-					Name:    ProviderNetworkName,
-					Url:     ProviderNetworkEndpoint,
-					Version: ProviderVersion1,
+					Name:    constants.NetworkProviderName,
+					Url:     ProviderNetworkV1Endpoint,
+					Version: constants.ApiVersion1,
 				},
 				{
-					Name:    ProviderComputeName,
-					Url:     ProviderComputeEndpoint,
-					Version: ProviderVersion1,
+					Name:    constants.ComputeProviderName,
+					Url:     ProviderComputeV1Endpoint,
+					Version: constants.ApiVersion1,
 				},
 				{
-					Name:    ProviderStorageName,
-					Url:     ProviderStorageEndpoint,
-					Version: ProviderVersion1,
+					Name:    constants.StorageProviderName,
+					Url:     ProviderStorageV1Endpoint,
+					Version: constants.ApiVersion1,
 				},
 			},
 		},
 	})
 	region.HandlerWithOptions(sim, region.StdHTTPServerOptions{
-		BaseURL:    ProviderRegionEndpoint,
+		BaseURL:    ProviderRegionV1Endpoint,
 		BaseRouter: sm,
 	})
 
@@ -59,42 +60,42 @@ func ConfigureRegionV1Handler(t *testing.T, sm *http.ServeMux) *mockregion.MockS
 
 func ConfigureAuthorizationHandler(sim *mockauthorization.MockServerInterface, sm *http.ServeMux) {
 	authorization.HandlerWithOptions(sim, authorization.StdHTTPServerOptions{
-		BaseURL:    ProviderAuthorizationEndpoint,
+		BaseURL:    ProviderAuthorizationV1Endpoint,
 		BaseRouter: sm,
 	})
 }
 
 func ConfigureComputeHandler(sim *mockcompute.MockServerInterface, sm *http.ServeMux) {
 	compute.HandlerWithOptions(sim, compute.StdHTTPServerOptions{
-		BaseURL:    ProviderComputeEndpoint,
+		BaseURL:    ProviderComputeV1Endpoint,
 		BaseRouter: sm,
 	})
 }
 
 func ConfigureNetworkHandler(sim *mocknetwork.MockServerInterface, sm *http.ServeMux) {
 	network.HandlerWithOptions(sim, network.StdHTTPServerOptions{
-		BaseURL:    ProviderNetworkEndpoint,
+		BaseURL:    ProviderNetworkV1Endpoint,
 		BaseRouter: sm,
 	})
 }
 
 func ConfigureRegionHandler(sim *mockregion.MockServerInterface, sm *http.ServeMux) {
 	region.HandlerWithOptions(sim, region.StdHTTPServerOptions{
-		BaseURL:    ProviderRegionEndpoint,
+		BaseURL:    ProviderRegionV1Endpoint,
 		BaseRouter: sm,
 	})
 }
 
 func ConfigureStorageHandler(sim *mockstorage.MockServerInterface, sm *http.ServeMux) {
 	storage.HandlerWithOptions(sim, storage.StdHTTPServerOptions{
-		BaseURL:    ProviderStorageEndpoint,
+		BaseURL:    ProviderStorageV1Endpoint,
 		BaseRouter: sm,
 	})
 }
 
 func ConfigureWorkspaceHandler(sim *mockworkspace.MockServerInterface, sm *http.ServeMux) {
 	workspace.HandlerWithOptions(sim, workspace.StdHTTPServerOptions{
-		BaseURL:    ProviderWorkspaceEndpoint,
+		BaseURL:    ProviderWorkspaceV1Endpoint,
 		BaseRouter: sm,
 	})
 }

--- a/pkg/constants/providers.go
+++ b/pkg/constants/providers.go
@@ -1,0 +1,11 @@
+package constants
+
+const (
+	// Providers
+	AuthorizationProviderName = "seca.authorization"
+	RegionProviderName        = "seca.region"
+	WorkspaceProviderName     = "seca.workspace"
+	StorageProviderName       = "seca.storage"
+	ComputeProviderName       = "seca.compute"
+	NetworkProviderName       = "seca.network"
+)

--- a/pkg/constants/providers_v1.go
+++ b/pkg/constants/providers_v1.go
@@ -1,0 +1,11 @@
+package constants
+
+const (
+	// Providers
+	AuthorizationProviderV1Name = AuthorizationProviderName + "/" + ApiVersion1
+	RegionProviderV1Name        = RegionProviderName + "/" + ApiVersion1
+	WorkspaceProviderV1Name     = WorkspaceProviderName + "/" + ApiVersion1
+	ComputeProviderV1Name       = ComputeProviderName + "/" + ApiVersion1
+	StorageProviderV1Name       = StorageProviderName + "/" + ApiVersion1
+	NetworkProviderV1Name       = NetworkProviderName + "/" + ApiVersion1
+)

--- a/pkg/constants/versions.go
+++ b/pkg/constants/versions.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	ApiVersion1 = "v1"
+)

--- a/secapi/region_v1_test.go
+++ b/secapi/region_v1_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/eu-sovereign-cloud/go-sdk/internal/secatest"
 	mockregion "github.com/eu-sovereign-cloud/go-sdk/mock/spec/foundation.region.v1"
+	"github.com/eu-sovereign-cloud/go-sdk/pkg/constants"
 	"github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
 	"github.com/eu-sovereign-cloud/go-sdk/secapi/builders"
 
@@ -20,7 +21,7 @@ func TestListRegionsV1(t *testing.T) {
 	sm := http.NewServeMux()
 
 	sim := mockregion.NewMockServerInterface(t)
-	spec := buildResponseRegionSpec(secatest.ProviderNetworkName, secatest.ProviderNetworkEndpoint, secatest.ProviderVersion1)
+	spec := buildResponseRegionSpec(constants.NetworkProviderName, secatest.ProviderNetworkV1Endpoint, constants.ApiVersion1)
 	secatest.MockListRegionsV1(sim, []schema.Region{
 		*buildResponseRegion(secatest.Region1Name, spec),
 		*buildResponseRegion(secatest.Region2Name, spec),
@@ -42,9 +43,9 @@ func TestListRegionsV1(t *testing.T) {
 	assert.Equal(t, secatest.Region1Name, resp[0].Metadata.Name)
 
 	assert.Len(t, resp[0].Spec.Providers, 1)
-	assert.Contains(t, resp[0].Spec.Providers[0].Name, secatest.ProviderNetworkName)
-	assert.Contains(t, resp[0].Spec.Providers[0].Url, secatest.ProviderNetworkEndpoint)
-	assert.Equal(t, secatest.ProviderVersion1, resp[0].Spec.Providers[0].Version)
+	assert.Contains(t, resp[0].Spec.Providers[0].Name, constants.NetworkProviderName)
+	assert.Contains(t, resp[0].Spec.Providers[0].Url, secatest.ProviderNetworkV1Endpoint)
+	assert.Equal(t, constants.ApiVersion1, resp[0].Spec.Providers[0].Version)
 }
 
 func TestListRegionsWithFiltersV1(t *testing.T) {
@@ -60,9 +61,9 @@ func TestListRegionsWithFiltersV1(t *testing.T) {
 			Spec: schema.RegionSpec{
 				Providers: []schema.Provider{
 					{
-						Name:    secatest.ProviderNetworkName,
-						Url:     secatest.ProviderNetworkEndpoint,
-						Version: secatest.ProviderVersion1,
+						Name:    constants.NetworkProviderName,
+						Url:     secatest.ProviderNetworkV1Endpoint,
+						Version: constants.ApiVersion1,
 					},
 				},
 			},
@@ -74,9 +75,9 @@ func TestListRegionsWithFiltersV1(t *testing.T) {
 			Spec: schema.RegionSpec{
 				Providers: []schema.Provider{
 					{
-						Name:    secatest.ProviderNetworkName,
-						Url:     secatest.ProviderNetworkEndpoint,
-						Version: secatest.ProviderVersion1,
+						Name:    constants.NetworkProviderName,
+						Url:     secatest.ProviderNetworkV1Endpoint,
+						Version: constants.ApiVersion1,
 					},
 				},
 			},
@@ -108,9 +109,9 @@ func TestListRegionsWithFiltersV1(t *testing.T) {
 	assert.Equal(t, secatest.Region1Name, resp[0].Metadata.Name)
 
 	assert.Len(t, resp[0].Spec.Providers, 1)
-	assert.Contains(t, resp[0].Spec.Providers[0].Name, secatest.ProviderNetworkName)
-	assert.Contains(t, resp[0].Spec.Providers[0].Url, secatest.ProviderNetworkEndpoint)
-	assert.Equal(t, secatest.ProviderVersion1, resp[0].Spec.Providers[0].Version)
+	assert.Contains(t, resp[0].Spec.Providers[0].Name, constants.NetworkProviderName)
+	assert.Contains(t, resp[0].Spec.Providers[0].Url, secatest.ProviderNetworkV1Endpoint)
+	assert.Equal(t, constants.ApiVersion1, resp[0].Spec.Providers[0].Version)
 }
 
 func TestGetRegionV1(t *testing.T) {
@@ -118,7 +119,7 @@ func TestGetRegionV1(t *testing.T) {
 	sm := http.NewServeMux()
 
 	sim := mockregion.NewMockServerInterface(t)
-	spec := buildResponseRegionSpec(secatest.ProviderNetworkName, secatest.ProviderNetworkEndpoint, secatest.ProviderVersion1)
+	spec := buildResponseRegionSpec(constants.NetworkProviderName, secatest.ProviderNetworkV1Endpoint, constants.ApiVersion1)
 	secatest.MockGetRegionV1(sim, buildResponseRegion(secatest.Region1Name, spec))
 	secatest.ConfigureRegionHandler(sim, sm)
 
@@ -132,9 +133,9 @@ func TestGetRegionV1(t *testing.T) {
 
 	assert.Equal(t, secatest.Region1Name, resp.Metadata.Name)
 
-	assert.Contains(t, resp.Spec.Providers[0].Name, secatest.ProviderNetworkName)
-	assert.Contains(t, resp.Spec.Providers[0].Url, secatest.ProviderNetworkEndpoint)
-	assert.Equal(t, secatest.ProviderVersion1, resp.Spec.Providers[0].Version)
+	assert.Contains(t, resp.Spec.Providers[0].Name, constants.NetworkProviderName)
+	assert.Contains(t, resp.Spec.Providers[0].Url, secatest.ProviderNetworkV1Endpoint)
+	assert.Equal(t, constants.ApiVersion1, resp.Spec.Providers[0].Version)
 }
 
 // Builders

--- a/secapi/tests.go
+++ b/secapi/tests.go
@@ -14,8 +14,8 @@ func newTestGlobalClientV1(t *testing.T, server *httptest.Server) *GlobalClient 
 	config := &GlobalConfig{
 		AuthToken: secatest.AuthToken,
 		Endpoints: GlobalEndpoints{
-			RegionV1:        server.URL + secatest.ProviderRegionEndpoint,
-			AuthorizationV1: server.URL + secatest.ProviderAuthorizationEndpoint,
+			RegionV1:        server.URL + secatest.ProviderRegionV1Endpoint,
+			AuthorizationV1: server.URL + secatest.ProviderAuthorizationV1Endpoint,
 		},
 	}
 	client, err := NewGlobalClient(config)


### PR DESCRIPTION
Sharing SDK provider constants to be used by ECP.
Closes #58 